### PR TITLE
Add predicate block to filter tests and prevent invalid generations from overwhelming valid test cases

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   NewCops: enable
 
+Layout/BeginEndAlignment:
+  Enabled: false
+
 Layout/LineLength:
   Exclude:
     - 'lib/minitest/proptest_plugin.rb'
@@ -9,6 +12,9 @@ Layout/SpaceInsideParens:
   Enabled: false
 
 Layout/MultilineArrayBraceLayout:
+  Enabled: false
+
+Layout/RescueEnsureAlignment:
   Enabled: false
 
 Metrics/ClassLength:

--- a/lib/minitest/proptest/property.rb
+++ b/lib/minitest/proptest/property.rb
@@ -106,13 +106,17 @@ module Minitest
       private
 
       def iterate!
-        while continue_iterate? && @result.nil? && @valid_test_cases <= @max_success / 2
+        while continue_iterate? && @result.nil? && @valid_test_cases <= @max_success
           @valid_test_case = true
           @generated = []
           @generator = ::Minitest::Proptest::Gen.new(@random)
           @calls += 1
 
-          success = instance_eval(&@test_proc)
+          success = begin
+                      instance_eval(&@test_proc)
+                    rescue => e
+                      raise e if @valid_test_case
+                    end
           if @valid_test_case && success
             @status = Status.valid if @status.unknown?
             @valid_test_cases += 1

--- a/lib/minitest/proptest/property.rb
+++ b/lib/minitest/proptest/property.rb
@@ -4,7 +4,7 @@ module Minitest
   module Proptest
     # Property evaluation - status, scoring, shrinking
     class Property
-      attr_reader :result, :status, :trivial
+      attr_reader :calls, :result, :status, :trivial
 
       def initialize(
         # The function which proves the property

--- a/lib/minitest/proptest/status.rb
+++ b/lib/minitest/proptest/status.rb
@@ -4,6 +4,10 @@ module Minitest
   module Proptest
     # Sum type representing the possible statuses of a test run.
     # Invalid, Overrun, and Interesting represent different failure classes.
+    # Exhausted represents having generated too many invalid test cases to
+    # verify the property.  This precipitates as a failure class (the property is
+    # not proved) but can be a matter of inappropriate predicates in `where`
+    # blocks.
     # Unknown represents a lack of information about the test run (typically
     # having not run to satisfaction).
     # Valid represents a test which has run to satisfaction.
@@ -23,16 +27,21 @@ module Minitest
       class Valid < Status
       end
 
+      class Exhausted < Status
+      end
+
       invalid     = Invalid.new.freeze
       interesting = Interesting.new.freeze
       overrun     = Overrun.new.freeze
       unknown     = Unknown.new.freeze
+      exhausted   = Exhausted.new.freeze
       valid       = Valid.new.freeze
 
       define_singleton_method(:invalid)     { invalid }
       define_singleton_method(:interesting) { interesting }
       define_singleton_method(:overrun)     { overrun }
       define_singleton_method(:unknown)     { unknown }
+      define_singleton_method(:exhausted)   { exhausted }
       define_singleton_method(:valid)       { valid }
 
       def invalid?
@@ -45,6 +54,10 @@ module Minitest
 
       def unknown?
         self.is_a?(Unknown)
+      end
+
+      def exhausted?
+        self.is_a?(Exhausted)
       end
 
       def valid?

--- a/lib/minitest/proptest_plugin.rb
+++ b/lib/minitest/proptest_plugin.rb
@@ -77,7 +77,7 @@ module Minitest
       if prop.status.valid? && !prop.trivial
         Proptest.strike_failure(file, classname, methodname)
       else
-        Proptest.record_failure(file, classname, methodname, prop.result.map(&:value))
+        Proptest.record_failure(file, classname, methodname, prop.result.map(&:value)) unless prop.status.exhausted?
 
         raise Minitest::Assertion, prop.explain
       end

--- a/lib/minitest/proptest_plugin.rb
+++ b/lib/minitest/proptest_plugin.rb
@@ -50,8 +50,6 @@ module Minitest
 
   module Assertions
     def property(&f)
-      self.assertions += 1
-
       random_thunk = if Proptest.instance_variable_defined?(:@_random_seed)
                        r = Proptest.instance_variable_get(:@_random_seed)
                        ->() { Proptest::DEFAULT_RANDOM.call(r) }
@@ -73,6 +71,7 @@ module Minitest
         previous_failure: Proptest.reporter.lookup(file, classname, methodname)
       )
       prop.run!
+      self.assertions += prop.calls
 
       if prop.status.valid? && !prop.trivial
         Proptest.strike_failure(file, classname, methodname)

--- a/lib/minitest/proptest_plugin.rb
+++ b/lib/minitest/proptest_plugin.rb
@@ -77,7 +77,9 @@ module Minitest
       if prop.status.valid? && !prop.trivial
         Proptest.strike_failure(file, classname, methodname)
       else
-        Proptest.record_failure(file, classname, methodname, prop.result.map(&:value)) unless prop.status.exhausted?
+        unless prop.status.exhausted? || prop.status.invalid?
+          Proptest.record_failure(file, classname, methodname, prop.result.map(&:value))
+        end
 
         raise Minitest::Assertion, prop.explain
       end

--- a/minitest-proptest.gemspec
+++ b/minitest-proptest.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
   s.metadata['homepage_uri'] = s.homepage
   s.metadata['source_code_uri'] = s.homepage
   s.metadata['changelog_uri'] = 'https://github.com/wuest/minitest-proptest/blob/main/CHANGELOG.md'
+  s.metadata['rubygems_mfa_required'] = 'true'
 
   s.files = `git ls-files lib`.split("\n")
 
   s.add_dependency 'minitest', '~> 5'
-  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/test/property_test.rb
+++ b/test/property_test.rb
@@ -279,4 +279,15 @@ class PropertyTest < Minitest::Test
       end
     end
   end
+
+  def test_where
+    property do
+      n = arbitrary Int32
+      where do
+        n.even?
+      end
+
+      n.even?
+    end
+  end
 end

--- a/test/should_fail/property_fails.rb
+++ b/test/should_fail/property_fails.rb
@@ -19,4 +19,15 @@ class PropertyTest < Minitest::Test
       xs.zip(ys).length > 1
     end
   end
+
+  def test_falsifiable_exhausts
+    property do
+      x = arbitrary UInt8
+      where do
+        x.negative?
+      end
+
+      x >= 0
+    end
+  end
 end


### PR DESCRIPTION
This adds a `where` method to properties, which allows the test framework to discard invalid cases.  Previously this was accomplished via additional predicates in property logic.

**Old**
```ruby
property do
  xs = arbitrary Array, Int8
  ys = arbitrary Array, Int8

  if xs.length <= ys.length
    xs.zip(ys).length == xs.length
  else
    # If the arbitrary data was inappropriate for constructing valid types,
    # fall through to success.
    # This ultimately represents having wasted a test case generation.
    true
  end
end
```

**New**
```ruby
property do
  xs = arbitrary Array, Int8
  ys = arbitrary Array, Int8

  # The property will be rejected unless all predicates contained in `where`
  # blocks are satisfied - this will re-generate the test parameters up to the
  # maximum number of discards (by default a 10:1 ratio vs successful runs
  # required to satisfy the property)
  where { xs.length <= ys.length }

  xs.zip(ys).length == xs.length
end
```