### PR TITLE
Improve signed int handling, speed up where blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,10 @@ Lint/BinaryOperatorWithIdenticalOperands:
   Exclude:
     - 'test/property_test.rb'
 
+Lint/SuppressedException:
+  Exclude:
+    - 'lib/minitest/proptest/property.rb'
+
 Metrics/BlockNesting:
   Exclude:
     - 'lib/minitest/proptest/property.rb'

--- a/lib/minitest/proptest/gen.rb
+++ b/lib/minitest/proptest/gen.rb
@@ -287,47 +287,27 @@ module Minitest
 
       generator_for(Int8) do
         r = sized(0xff)
-        (r & 0x80).zero? ? r : -(((r & 0x7f) - 1) ^ 0x7f)
-      end.with_shrink_function do |i|
-        j = (i & 0x80).zero? ? i : -(((i & 0x7f) - 1) ^ 0x7f)
-        integral_shrink.call(j)
-      end
+        (r & 0x80).zero? ? r : -((r ^ 0x7f) - 0x7f)
+      end.with_shrink_function(&integral_shrink)
 
       generator_for(Int16) do
         r = sized(0xffff)
-        (r & 0x8000).zero? ? r : -(((r & 0x7fff) - 1) ^ 0x7fff)
-      end.with_shrink_function do |i|
-        j = (i & 0x8000).zero? ? i : -(((i & 0x7fff) - 1) ^ 0x7fff)
-        integral_shrink.call(j)
-      end
+        (r & 0x8000).zero? ? r : -((r ^ 0x7fff) - 0x7fff)
+      end.with_shrink_function(&integral_shrink)
 
       generator_for(Int32) do
         r = sized(0xffffffff)
-        (r & 0x80000000).zero? ? r : -(((r & 0x7fffffff) - 1) ^ 0x7fffffff)
-      end.with_shrink_function do |i|
-        j = if (i & 0x80000000).zero?
-              i
-            else
-              -(((i & 0x7fffffff) - 1) ^ 0x7fffffff)
-            end
-        integral_shrink.call(j)
-      end
+        (r & 0x80000000).zero? ? r : -((r ^ 0x7fffffff) - 0x7fffffff)
+      end.with_shrink_function(&integral_shrink)
 
       generator_for(Int64) do
         r = sized(0xffffffffffffffff)
         if (r & 0x8000000000000000).zero?
           r
         else
-          -(((r & 0x7fffffffffffffff) - 1) ^ 0x7fffffffffffffff)
+          -((r ^ 0x7fffffffffffffff) - 0x7fffffffffffffff)
         end
-      end.with_shrink_function do |i|
-        j = if (i & 0x8000000000000000).zero?
-              i
-            else
-              -(((i & 0x7fffffffffffffff) - 1) ^ 0x7fffffffffffffff)
-            end
-        integral_shrink.call(j)
-      end
+      end.with_shrink_function(&integral_shrink)
 
       generator_for(UInt8) do
         sized(0xff)

--- a/lib/minitest/proptest/gen/value_generator.rb
+++ b/lib/minitest/proptest/gen/value_generator.rb
@@ -98,7 +98,11 @@ module Minitest
         def shrink_candidates
           fs = @type_parameters.map { |x| x.method(:shrink_function) }
           os = score
-          candidates = shrink_function(*fs, value)
+          # Ensure that the end of the shrink attempt will contain the original
+          # value.  This is necessary to guarantee that the shrink process
+          # produces at least one failure for the purpose of capturing variable
+          # assignment.
+          candidates = shrink_function(*fs, value) + [value]
           candidates
             .map    { |c| [force(c).score, c] }
             .reject { |(s, _)| s > os }

--- a/test/property_test.rb
+++ b/test/property_test.rb
@@ -11,7 +11,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0x7f && x >= -0x80 &&
           ( n < 0 ? x <= 1 : x >= -1 )
@@ -27,7 +27,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0x7fff && x >= -0x8000 &&
           ( n < 0 ? x <= 1 : x >= -1 )
@@ -43,7 +43,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0x7fffffff && x >= -0x80000000 &&
           ( n < 0 ? x <= 1 : x >= -1 )
@@ -59,7 +59,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0x7fffffffffffffff && x >= -0x8000000000000000 &&
           ( n < 0 ? x <= 1 : x >= -1 )
@@ -75,7 +75,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0x7fffffffffffffff && x >= -0x8000000000000000 &&
           ( n < 0 ? x <= 1 : x >= -1 )
@@ -91,7 +91,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0xff &&
           x >= 0
@@ -107,7 +107,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0xffff &&
           x >= 0
@@ -123,7 +123,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0xffffffff &&
           x >= 0
@@ -139,7 +139,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.abs < n.abs &&
+        x.abs <= n.abs &&
           score == x.abs &&
           x <= 0xffffffffffffffff &&
           x >= 0
@@ -158,7 +158,7 @@ class PropertyTest < Minitest::Test
         if x.nan? || x.infinite?
           score.zero?
         else
-          score == x.abs.ceil && x.abs < n.abs
+          score == x.abs.ceil && x.abs <= n.abs
         end
       end
     end
@@ -175,7 +175,7 @@ class PropertyTest < Minitest::Test
         if x.nan? || x.infinite?
           score.zero?
         else
-          score == x.abs.ceil && x.abs < n.abs
+          score == x.abs.ceil && x.abs <= n.abs
         end
       end
     end
@@ -192,7 +192,7 @@ class PropertyTest < Minitest::Test
         if x.nan? || x.infinite?
           score.zero?
         else
-          score == x.abs.ceil && x.abs < n.abs
+          score == x.abs.ceil && x.abs <= n.abs
         end
       end
     end
@@ -251,7 +251,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, _|
-        score < g.score
+        score <= g.score
       end
     end
   end
@@ -264,7 +264,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, _|
-        score < g.score
+        score <= g.score
       end
     end
   end
@@ -277,7 +277,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.ord < c.ord &&
+        x.ord <= c.ord &&
           score == x.ord &&
           x.ord <= 0xff && x.ord >= 0
       end
@@ -292,7 +292,7 @@ class PropertyTest < Minitest::Test
       candidates = g.shrink_candidates
 
       candidates.all? do |score, x|
-        x.ord < c.ord &&
+        x.ord <= c.ord &&
           score == x.ord &&
           x.ord <= 0x7f && x.ord >= 0
       end

--- a/test/should_fail/property_fails.rb
+++ b/test/should_fail/property_fails.rb
@@ -30,4 +30,11 @@ class PropertyTest < Minitest::Test
       x >= 0
     end
   end
+
+  def test_falsifiable_assert
+    property do
+      x = arbitrary UInt8
+      assert x.even?
+    end
+  end
 end


### PR DESCRIPTION
Integer handling is improved - fewer operations per integer generated, fencepost error caught by the tests and fixed.
`where` now short-circuits, and the `iterate!` `shrink!` and `rerun!` methods are simplified as well.