### PR TITLE
Update TracePoint logic to track internal variable names for shrink function under Ruby 4.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-24.04' ]
-        ruby-version: ['3.2', '3.3', '3.4', '4.0']
+        ruby-version: ['3.3', '3.4', '4.0']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-24.04' ]
-        ruby-version: ['3.2']
+        ruby-version: ['4.0']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/lib/minitest/proptest/property.rb
+++ b/lib/minitest/proptest/property.rb
@@ -18,6 +18,8 @@ module Minitest
         test_proc,
         # The file in which our property lives
         filename,
+        # The class in which our property is defined
+        classname,
         # The method containing our property
         methodname,
         # Any class which provides `rand` accepting both an Integer and a Range
@@ -40,6 +42,7 @@ module Minitest
       )
         @test_proc         = test_proc
         @filename          = filename
+        @classname         = classname
         @methodname        = methodname
         @random            = random.call
         @generator         = ::Minitest::Proptest::Gen.new(@random)
@@ -219,7 +222,7 @@ module Minitest
         # required.
         local_variables = {}
         tracepoint = TracePoint.new(:b_return) do |trace|
-          if trace.path == @filename && trace.method_id.to_s == @methodname
+          if trace.path == @filename && trace.method_id == @methodname && trace.defined_class == @classname
             b     = trace.binding
             vs    = b.local_variables
             known = vs.to_h { |lv| [lv.to_s, b.local_variable_get(lv)] }

--- a/lib/minitest/proptest/version.rb
+++ b/lib/minitest/proptest/version.rb
@@ -2,6 +2,6 @@
 
 module Minitest
   module Proptest
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end

--- a/lib/minitest/proptest_plugin.rb
+++ b/lib/minitest/proptest_plugin.rb
@@ -57,13 +57,15 @@ module Minitest
                        Proptest::DEFAULT_RANDOM
                      end
 
-      file, methodname = caller.first.split(/:\d+:in +/)
-      classname = self.class.name
-      methodname.gsub!(/(?:^`|'$)/, '')
+      file, full_method = caller.first.split(/:\d+:in +/)
+      classname, methodname = full_method.gsub!(/(?:^[`']|'$)/, '').split(/[#.]/, 2)
+      classname = classname.split('::').reduce(Kernel, &:const_get)
+      methodname = methodname.to_sym
 
       prop = Minitest::Proptest::Property.new(
         f,
         file,
+        classname,
         methodname,
         random: random_thunk,
         max_success: Proptest.max_success,

--- a/lib/minitest/proptest_plugin.rb
+++ b/lib/minitest/proptest_plugin.rb
@@ -58,8 +58,8 @@ module Minitest
                      end
 
       file, full_method = caller.first.split(/:\d+:in +/)
-      classname, methodname = full_method.gsub!(/(?:^[`']|'$)/, '').split(/[#.]/, 2)
-      classname = classname.split('::').reduce(Kernel, &:const_get)
+      methodname = full_method.gsub(/(?:^.+[#.]|'$)/, '')
+      classname = self.class.name
       methodname = methodname.to_sym
 
       prop = Minitest::Proptest::Property.new(

--- a/minitest-proptest.gemspec
+++ b/minitest-proptest.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/wuest/minitest-proptest'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 3.2.0'
+  s.required_ruby_version = '>= 3.3.0'
 
   s.metadata['homepage_uri'] = s.homepage
   s.metadata['source_code_uri'] = s.homepage


### PR DESCRIPTION
TracePoint changed under Ruby 4.x, so failures would not be able to report the results of the shrink step once a property was invalidated.  This updates the logic to work for all non-EOL rubies.